### PR TITLE
Add useful types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 /pkg/
 /spec/reports/
 /tmp/
+/thy-*.gem
 
 # rspec failure tracking
 .rspec_status

--- a/README.md
+++ b/README.md
@@ -126,6 +126,10 @@ Thy::Integer.check(3).success? # => true
 # Boolean
 Thy::Boolean.check(true).success? # => true
 Thy::Boolean.check(false).success? # => true
+
+# nil
+Thy::Nil.check(nil).success? # => true
+Thy::Nil.check(0).success? # => false
 ```
 
 ### Parameterized types
@@ -154,6 +158,17 @@ Thy::Variant('USD', 'EUR').check('EUR').success? # => true
 # Option
 Thy::Option(Thy::String).check('a string').success? # => true
 Thy::Option(Thy::String).check(nil).success? # => true
+
+# InstanceOf
+class A; end
+class B < A; end
+class C; end
+Thy::InstanceOf(A).check(B.new).success? # => true
+Thy::InstanceOf(A).check(C.new).success? # => false
+
+# ClassExtending
+Thy::ClassExtending(A).check(B).success? # => true
+Thy::ClassExtending(A).check(C).success? # => false
 ```
 
 ### Other types

--- a/lib/thy.rb
+++ b/lib/thy.rb
@@ -9,6 +9,7 @@ require 'thy/types/numeric'
 require 'thy/types/integer'
 require 'thy/types/float'
 require 'thy/types/boolean'
+require 'thy/types/nil'
 
 require 'thy/types/array'
 require 'thy/types/untyped_array'
@@ -21,6 +22,9 @@ require 'thy/types/enum'
 require 'thy/types/variant'
 
 require 'thy/types/option'
+
+require 'thy/types/instance_of'
+require 'thy/types/class_extending'
 
 require 'thy/result/success'
 require 'thy/result/failure'

--- a/lib/thy/types.rb
+++ b/lib/thy/types.rb
@@ -30,6 +30,14 @@ module Thy::Types
     def Option(type)
       Option.new(type)
     end
+
+    def InstanceOf(klass)
+      InstanceOf.new(klass)
+    end
+
+    def ClassExtending(klass)
+      ClassExtending.new(klass)
+    end
     # rubocop:enable Naming/MethodName
   end
 end

--- a/lib/thy/types/class_extending.rb
+++ b/lib/thy/types/class_extending.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module Thy
+  module Types
+    class ClassExtending
+      def initialize(klass)
+        @klass = klass
+      end
+
+      def check(value)
+        unless value.is_a?(::Class)
+          return Failure.new("Expected #{value.inspect} to be a Class")
+        end
+
+        if value.ancestors.include?(@klass)
+          Result::Success
+        else
+          Result::Failure.new(
+            "Expected #{value.inspect} to be a descendant of: #{@klass.inspect}",
+          )
+        end
+      end
+    end
+  end
+end

--- a/lib/thy/types/instance_of.rb
+++ b/lib/thy/types/instance_of.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Thy
+  module Types
+    class InstanceOf
+      def initialize(klass)
+        @klass = klass
+      end
+
+      def check(value)
+        if value.is_a?(@klass)
+          Result::Success
+        else
+          Result::Failure.new("Expected #{value.inspect} to be an instance of: #{@klass.inspect}")
+        end
+      end
+    end
+  end
+end

--- a/lib/thy/types/nil.rb
+++ b/lib/thy/types/nil.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Thy
+  module Types
+    module Nil
+      def self.check(value)
+        if value.nil?
+          Result::Success
+        else
+          Result::Failure.new("Expected nil, but got: #{value.inspect}")
+        end
+      end
+    end
+  end
+end

--- a/spec/thy_spec.rb
+++ b/spec/thy_spec.rb
@@ -33,6 +33,13 @@ RSpec.describe Thy do
     end
   end
 
+  context 'nil type' do
+    specify do
+      expect(described_class::Nil.check(nil).success?).to eq(true)
+      expect(described_class::Nil.check(0).success?).to eq(false)
+    end
+  end
+
   context 'complex types' do
     it 'provides enums' do
       enum = described_class::Variant(described_class::String, described_class::Integer)
@@ -132,6 +139,34 @@ RSpec.describe Thy do
         expect(hsh.check(1 => 'kek').success?).to eq(false)
       end
     end
+
+    context 'instance of' do
+      before do
+        stub_const('MyClass', Class.new)
+        stub_const('OtherClass', Class.new)
+      end
+
+      let(:instance) { MyClass.new }
+      let(:other_instance) { OtherClass.new }
+
+      specify do
+        expect(described_class::InstanceOf(MyClass).check(instance).success?).to eq(true)
+        expect(described_class::InstanceOf(MyClass).check(other_instance).success?).to eq(false)
+      end
+    end
+
+    context 'class extending' do
+      before do
+        stub_const('MyClass', Class.new)
+        stub_const('Descendant', Class.new(MyClass))
+        stub_const('OtherClass', Class.new)
+      end
+
+      specify do
+        expect(described_class::ClassExtending(MyClass).check(Descendant).success?).to eq(true)
+        expect(described_class::ClassExtending(MyClass).check(OtherClass).success?).to eq(false)
+      end
+    end
   end
 
   context 'custom types' do
@@ -168,7 +203,7 @@ RSpec.describe Thy do
 
   describe 'type composition' do
     let(:non_zero_integer) do
-      described_class::refine_type(
+      described_class.refine_type(
         described_class::Integer,
         described_class::Type.new { |v| v != 0 },
       )


### PR DESCRIPTION
During development with Thy, there arose a need to introduce three types that are needed extensively. These are `ClassExtending`, `InstanceOf`, and `Nil`. Refer to README for documentation.